### PR TITLE
Allow usage with node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "host": "https://github.com/jshor/symbology/releases/download/"
   },
   "engines": {
-    "node": ">=14.0.0 <17.0.0"
+    "node": ">=14.0.0 <19.0.0"
   },
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.7",


### PR DESCRIPTION
Add engines up to v18 to allowed node versions