### PR TITLE
fix(svg): adds fix for SVG/EPS crashes #96

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-2019, ubuntu-latest, macos-latest]
         # list only the earliest and latest node versions supported
         # this makes PR builds more efficient
         node-version: [14, 16]
@@ -23,7 +23,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: yarn
+
+      - name: Run linter
+        run: yarn lint
+
       - name: Build binaries
         run: yarn build
+
       - name: Run tests
         run: yarn test

--- a/src/lib/binary.ts
+++ b/src/lib/binary.ts
@@ -71,11 +71,6 @@ function invoke (config: SymbologyConfig, barcodeData: string, outputType: Outpu
   const res = binary.createBuffer(symbol, barcodeData)
 
   if (res.code <= 2) {
-    // remove all data after the trailing EOF marker
-    res.encodedData = res
-      .encodedData
-      .split('<<< EOF >>>')[0]
-
     if (res.code === 0) {
       res.message = 'Symbology successfully created.'
     }


### PR DESCRIPTION
This changes the output of EPS and SVG data to write to a string buffer instead of a file buffer. This fixes the issue where the binary would crash after a substantial number of iterations.