### PR TITLE
Add support for node 18

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019, macos-latest, ubuntu-latest]
-        node-version: [14, 16]
+        node-version: [14, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
         os: [windows-2019, ubuntu-latest, macos-latest]
         # list only the earliest and latest node versions supported
         # this makes PR builds more efficient
-        node-version: [14, 16]
+        node-version: [14, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "host": "https://github.com/jshor/symbology/releases/download/"
   },
   "engines": {
-    "node": ">=14.0.0 <17.0.0"
+    "node": ">=14.0.0 <19.0.0"
   },
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.10",


### PR DESCRIPTION
As per #105, adds support for node 18 to engines and GH workflows.