### PR TITLE
chore(package): specify manager as yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "typescript": ">=3.0.0",
     "vuepress": "^2.0.0-beta.53"
   },
+  "packageManager": "yarn@1.22.22",
   "peerDependencies": {
     "@mapbox/node-pre-gyp": "^1.0.2"
   },


### PR DESCRIPTION
Allows to use node's corepack feature to speed up development / contribution process as developers can use the correct package manager right away.