### PR TITLE
chore(deps)!: update node to v22, dropping v16

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        node-version: [16, 18, 20]
+        node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
         # list only the earliest and latest node versions supported
         # this makes PR builds more efficient
-        node-version: [16, 20]
+        node-version: [18, 22]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "host": "https://github.com/jshor/symbology/releases/download/"
   },
   "engines": {
-    "node": ">=14.0.0 <21.0.0"
+    "node": ">=14.0.0 <23.0.0"
   },
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.11",


### PR DESCRIPTION
Node 22 entered the `active` phase and Node 16 is out of maintenance now.